### PR TITLE
Potential fix for code scanning alert no. 365: Server-side request forgery

### DIFF
--- a/test/e2e/middleware-general/app/middleware.js
+++ b/test/e2e/middleware-general/app/middleware.js
@@ -186,7 +186,8 @@ export async function middleware(request) {
   }
 
   if (url.pathname.endsWith('/root-subrequest')) {
-    const res = await fetch(url)
+    const safeUrl = new URL('/', request.url)
+    const res = await fetch(safeUrl)
     res.headers.set('x-dynamic-path', 'true')
     return res
   }


### PR DESCRIPTION
Potential fix for [https://github.com/Rose2161/next.js/security/code-scanning/365](https://github.com/Rose2161/next.js/security/code-scanning/365)

In general, the fix is to avoid passing a user-controlled URL directly into `fetch`. Instead, construct the URL for the outgoing request from trusted building blocks: a fixed origin (e.g., the current host or a configured base URL) and, if needed, a restricted subset of the path/query that has been validated or normalized. This breaks the taint flow from untrusted request values into the HTTP client.

In this specific file, we should change the `fetch(url)` call in the `/root-subrequest` block so that it does not take `url` (which comes from `request.nextUrl`) directly. A minimal fix that preserves behavior for this test route is to create a new `URL` instance using a trusted origin derived from `request.url` but with a fixed path `/` (or another known-safe path) and, optionally, copy only safe components (or ignore them entirely). This keeps the subrequest same-origin while preventing the client from influencing the hostname or arbitrary path of the outgoing request.

Concretely:
- In `middleware`, inside the `if (url.pathname.endsWith('/root-subrequest')) { ... }` block (around lines 188–192), replace `const res = await fetch(url)` with code that constructs a safe URL, e.g.:

  ```js
  const safeUrl = new URL('/', request.url)
  const res = await fetch(safeUrl)
  ```

  This uses `request.url` only as a base for origin (scheme/host/port), while fixing the path to `/`, removing user control from the request target.
- No new imports or helper functions are strictly required, as `URL` is already used elsewhere in the file (and is globally available in this environment).

This change removes the tainted data flow into `fetch` without altering the general intent of doing a same-origin subrequest in the `/root-subrequest` case.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
